### PR TITLE
Add auto-refresh capabilitiles to token info cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,28 @@ This repo provides a basic keycloak client in go.
 
 The keycloak client in this repo is valid for the [Keycloak API @v4.8.3.Final](https://www.keycloak.org/docs-api/4.8/rest-api/index.html)
 
+## Tokens and Refreshing
+
+The client will fetch tokens based a realm and user credentials (username/password). The token fetched by the client will get cached in memory. On each use, the client will verify the cached token is still valid and if necessary, extend the session using the refresh token, or establish a new session using the provided credentials.
+
+### Automatic refreshing
+
+If you would like to ensure the token cache is always warm, you can enable auto-refreshing. When the client's auth token is 5 seconds from expiration, a background process will refresh the token either by extending the session using the refresh token, or establishing a nw session using the provided credentials.
+
+When starting automatic refresh, provide a method to handle errors when the refresh fails. This method could organize retries, panic, log the
+error and move on, etc. Whatever makes sense for the application using the client.
+
+```go
+realm := example
+username := admin
+password := secret
+func onFailure(err error) {
+	log.Printf("Unable to auto refresh token: %v. Retrying...", err)
+	// Retry after 30 seconds
+	time.AfterFunc(30 * time.Second, func(){
+		log.Print("Retrying auto refresh of Keycloak token")
+		client.AutoRefreshToken(realm, username, password, onFailure)
+	})
+}
+client.AutoRefreshToken(realm, username, password, onFailure)
+```

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ When starting automatic refresh, provide a method to handle errors when the refr
 error and move on, etc. Whatever makes sense for the application using the client.
 
 ```go
-realm := example
-username := admin
-password := secret
+realm := "example"
+username := "admin"
+password := "secret"
 func onFailure(err error) {
 	log.Printf("Unable to auto refresh token: %v. Retrying...", err)
 	// Retry after 30 seconds

--- a/keycloak_client.go
+++ b/keycloak_client.go
@@ -249,11 +249,11 @@ func (c *Client) GetToken(realm string, username string, password string) (strin
 }
 
 // AutoRefreshToken starts a process where an access token is kept perpetually
-// warm in the cache, refreshing itself five seconds before it is needed.
+// warm in the cache, refreshing itself five seconds before it expires.
 func (c *Client) AutoRefreshToken(realm string, username string, password string, onFailure func(error)) {
 	info, err := c.GetTokenInfo(realm, username, password, true)
 	if err != nil {
-		// Unable to fetch teh token, allow userland to determine the correct
+		// Unable to fetch the token, allow userland to determine the correct
 		// behavior here -- retry, panic, log, etc...
 		onFailure(err)
 		return


### PR DESCRIPTION
Allows auto-refresh to get turned on/off for a set of credentials. refreshes the token with 5 second left. Provides a callback method for failures (took a while to come to this...) so that the consumer can decide on behavior, retry, logging, exiting, panic, etc. We'll use it to retry when Keycloak is restarting or has not finished initializing yet.