### PR TITLE
Add logging plugin compatible with client-go

### DIFF
--- a/keycloak_client.go
+++ b/keycloak_client.go
@@ -121,6 +121,11 @@ func New(config Config) (*Client, error) {
 	}, nil
 }
 
+// LogRequests sets up a client plugin to log requests
+func (c *Client) LogRequests(logger RequestLogger) {
+	c.httpClient = c.httpClient.Use(loggerPlugin(logger))
+}
+
 func (c *Client) doTokenRequest(realm, bodyString string) (*TokenInfo, error) {
 	var req *gentleman.Request
 	{

--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,60 @@
+package keycloak
+
+import (
+	"net/http"
+	"time"
+
+	"gopkg.in/h2non/gentleman.v2/context"
+	"gopkg.in/h2non/gentleman.v2/plugin"
+)
+
+// RequestLogger wraps indicates a logger with a Debugf method
+type RequestLogger interface {
+	Debugf(string, ...interface{})
+}
+
+type loggingTransport struct {
+	writer RequestLogger
+	parent http.RoundTripper
+}
+
+func newLoggingRoundTripper(logger RequestLogger, parent http.RoundTripper) http.RoundTripper {
+	return &loggingTransport{
+		writer: logger,
+		parent: parent,
+	}
+}
+
+func (lt *loggingTransport) parentTransport() http.RoundTripper {
+	if lt.parent == nil {
+		return http.DefaultTransport
+	}
+	return lt.parent
+}
+
+func (lt *loggingTransport) CancelRequest(req *http.Request) {
+	type canceler interface {
+		CancelRequest(*http.Request)
+	}
+	if cr, ok := lt.parentTransport().(canceler); ok {
+		cr.CancelRequest(req)
+	}
+}
+
+func (lt *loggingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	startTime := time.Now()
+	at := req.Header.Get("Date")
+	if at == "" {
+		at = startTime.String()
+	}
+	resp, err := lt.parentTransport().RoundTrip(req)
+	lt.writer.Debugf("%s request to %s at %s took %s", req.Method, req.URL, at, time.Now().Sub(startTime))
+	return resp, err
+}
+
+func loggerPlugin(logger RequestLogger) plugin.Plugin {
+	return plugin.NewRequestPlugin(func(c *context.Context, h context.Handler) {
+		c.Client.Transport = newLoggingRoundTripper(logger, nil)
+		h.Next(c)
+	})
+}


### PR DESCRIPTION
Building from the client-go implementation, this only took 15 minutes to put together and useful since most of the service calls from identity are to keycloak...

Props to @efabens for noting a similar interceptor (plugin) like interfaces was available here.