### PR TITLE
SAML XML descriptor fetch

### DIFF
--- a/well_known.go
+++ b/well_known.go
@@ -8,7 +8,7 @@ const (
 	samlDescriptorPath = "/auth/realms/:realm/protocol/saml/descriptor"
 )
 
-// GetClientRoles gets all roles for the realm or client
+// GetSAMLDescriptor fetches the public XML IDP descriptor document for a realm
 func (c *Client) GetSAMLDescriptor(realmName string) (string, error) {
 	req := c.httpClient.Get()
 	resp, err := c.doRequest(req, url.Path(samlDescriptorPath), url.Param("realm", realmName))

--- a/well_known.go
+++ b/well_known.go
@@ -1,0 +1,16 @@
+package keycloak
+
+import (
+	"gopkg.in/h2non/gentleman.v2/plugins/url"
+)
+
+const (
+	samlDescriptorPath = "/auth/realms/:realm/protocol/saml/descriptor"
+)
+
+// GetClientRoles gets all roles for the realm or client
+func (c *Client) GetSAMLDescriptor(realmName string) (string, error) {
+	req := c.httpClient.Get()
+	resp, err := c.doRequest(req, url.Path(samlDescriptorPath), url.Param("realm", realmName))
+	return resp.String(), err
+}


### PR DESCRIPTION
Make gentleman compatible requester without auth, and initial well-known methods. Start with just SAML XML, since that's all we need at the moment.